### PR TITLE
Add missing country Georgia 🇬🇪

### DIFF
--- a/src/lib/regions.js
+++ b/src/lib/regions.js
@@ -86,6 +86,7 @@ const appStoreRegions = {
         { code: 'fr', name: 'France', emoji: '🇫🇷' },
         { code: 'gb', name: 'United Kingdom', emoji: '🇬🇧' },
         { code: 'gr', name: 'Greece', emoji: '🇬🇷' },
+        { code: 'ge', name: 'Georgia', emoji: '🇬🇪' },
         { code: 'hr', name: 'Croatia', emoji: '🇭🇷' },
         { code: 'hu', name: 'Hungary', emoji: '🇭🇺' },
         { code: 'ie', name: 'Ireland', emoji: '🇮🇪' },


### PR DESCRIPTION
Add missing country Georgia 🇬🇪 in Europe

fixes: https://github.com/gaia-charge/app-not-available/issues/2